### PR TITLE
Feature/support template files in subdirectories

### DIFF
--- a/domain/plugins/gui/templates/template.go
+++ b/domain/plugins/gui/templates/template.go
@@ -13,6 +13,7 @@ import (
 func parseTemplates() *template.Template {
 	files, err := listFiles(TemplateFileSystem)
 	if err != nil {
+		log.Error(context.Background(), err)
 		panic(err)
 	}
 	t, e := vfstemplate.ParseFiles(TemplateFileSystem, nil, files...)

--- a/domain/plugins/gui/templates/template.go
+++ b/domain/plugins/gui/templates/template.go
@@ -2,16 +2,52 @@ package templates
 
 import (
 	"context"
+	"html/template"
+	"net/http"
+	"path"
+
 	"github.com/d-velop/dvelop-sdk-go/log"
 	"github.com/shurcooL/httpfs/html/vfstemplate"
-	"html/template"
 )
 
 func parseTemplates() *template.Template {
-	t, e := vfstemplate.ParseGlob(TemplateFileSystem, nil, "*")
+	files, err := listFiles(TemplateFileSystem)
+	if err != nil {
+		panic(err)
+	}
+	t, e := vfstemplate.ParseFiles(TemplateFileSystem, nil, files...)
 	if e != nil {
 		log.Error(context.Background(), e)
 		panic(e)
 	}
 	return t
+}
+
+func listFiles(fs http.FileSystem) ([]string, error) {
+	var res []string
+	if err := readDirRecursive(fs, "/", &res); err != nil {
+		return nil, err
+	}
+	return res, nil
+}
+
+func readDirRecursive(fs http.FileSystem, dir string, res *[]string) error {
+	f, err := fs.Open(dir)
+	if err != nil {
+		return err
+	}
+	files, err := f.Readdir(-1)
+	if err != nil {
+		return err
+	}
+	for _, fi := range files {
+		if fi.IsDir() {
+			if err := readDirRecursive(fs, path.Join(dir, fi.Name()), res); err != nil {
+				return err
+			}
+			continue
+		}
+		*res = append(*res, path.Join(dir, fi.Name()))
+	}
+	return nil
 }

--- a/domain/plugins/gui/templates/template_prod.go
+++ b/domain/plugins/gui/templates/template_prod.go
@@ -9,6 +9,6 @@ import (
 )
 
 var t = parseTemplates() // cache parsed templates for production deployments
-func Render (w io.Writer, data interface{}, templatename string) error{
-	return t.ExecuteTemplate(w,templatename,data)
+func Render(w io.Writer, data interface{}, templatename string) error {
+	return t.ExecuteTemplate(w, templatename, data)
 }

--- a/domain/plugins/gui/templates/template_prod.go
+++ b/domain/plugins/gui/templates/template_prod.go
@@ -1,6 +1,6 @@
 // +build release
 
-//go:generate go run templatefs_generate.go --workdir ../../../../
+//go:generate go run -tags release templatefs_generate.go --workdir ../../../../
 
 package templates
 

--- a/domain/plugins/gui/templates/templatefs.go
+++ b/domain/plugins/gui/templates/templatefs.go
@@ -1,0 +1,19 @@
+package templates
+
+import (
+	"net/http"
+	"os"
+	"path"
+
+	"github.com/shurcooL/httpfs/filter"
+)
+
+var HTMLTemplates = filter.Keep(http.Dir("./web/"), func(filepath string, file os.FileInfo) bool {
+	if file.IsDir() {
+		return true
+	}
+	if path.Ext(filepath) == ".html" {
+		return true
+	}
+	return false
+})

--- a/domain/plugins/gui/templates/templatefs_dev.go
+++ b/domain/plugins/gui/templates/templatefs_dev.go
@@ -2,21 +2,5 @@
 
 package templates
 
-import (
-	"github.com/shurcooL/httpfs/filter"
-	"net/http"
-	"os"
-	"path"
-)
-
 // TemplateFileSystem contains the template files and maps to a native filesystem during development
-var TemplateFileSystem = filter.Keep(http.Dir("./web/"), func(filepath string, file os.FileInfo) bool {
-	if file.IsDir() {
-		return true
-	}
-	if path.Ext(filepath) == ".html" {
-		return true
-	}
-	return false
-})
-
+var TemplateFileSystem = HTMLTemplates

--- a/domain/plugins/gui/templates/templatefs_generate.go
+++ b/domain/plugins/gui/templates/templatefs_generate.go
@@ -8,11 +8,9 @@ package main
 import (
 	"flag"
 	"log"
-	"net/http"
 	"os"
-	"path"
 
-	"github.com/shurcooL/httpfs/filter"
+	"github.com/d-velop/dvelop-app-template-go/domain/plugins/gui/templates"
 	"github.com/shurcooL/vfsgen"
 )
 
@@ -22,17 +20,7 @@ func main() {
 	flag.Parse()
 	os.Chdir(wd)
 
-	var templateFileSystem = filter.Keep(http.Dir("./web/"), func(filepath string, file os.FileInfo) bool {
-		if file.IsDir() {
-			return true
-		}
-		if path.Ext(filepath) == ".html" {
-			return true
-		}
-		return false
-	})
-
-	err := vfsgen.Generate(templateFileSystem, vfsgen.Options{
+	err := vfsgen.Generate(templates.HTMLTemplates, vfsgen.Options{
 		Filename:        "./domain/plugins/gui/templates/templatefs_prod_gen.go",
 		PackageName:     "templates",
 		BuildTags:       "release",

--- a/domain/plugins/gui/templates/templatefs_generate.go
+++ b/domain/plugins/gui/templates/templatefs_generate.go
@@ -7,10 +7,12 @@ package main
 
 import (
 	"flag"
-	"github.com/d-velop/dvelop-app-template-go/domain/plugins/gui/templates"
 	"log"
+	"net/http"
 	"os"
+	"path"
 
+	"github.com/shurcooL/httpfs/filter"
 	"github.com/shurcooL/vfsgen"
 )
 
@@ -20,7 +22,17 @@ func main() {
 	flag.Parse()
 	os.Chdir(wd)
 
-	err := vfsgen.Generate(templates.TemplateFileSystem, vfsgen.Options{
+	var templateFileSystem = filter.Keep(http.Dir("./web/"), func(filepath string, file os.FileInfo) bool {
+		if file.IsDir() {
+			return true
+		}
+		if path.Ext(filepath) == ".html" {
+			return true
+		}
+		return false
+	})
+
+	err := vfsgen.Generate(templateFileSystem, vfsgen.Options{
 		Filename:        "./domain/plugins/gui/templates/templatefs_prod_gen.go",
 		PackageName:     "templates",
 		BuildTags:       "release",


### PR DESCRIPTION
Closes #8 

Parse the given http.FileSystem recursively and pluck out all html files to be used as template files.

This works but has one flaw that filenames have to be unique across all directories of the referenced http.FileSystem directory. To reference a template in the temple.Render function use the filename
of the template without the path.

Additionally fix templatefs_generate.go referenced a variable from the template_dev.go file. And go fmt (goimport style) some files.